### PR TITLE
Get .NET Framework tests running on Appveyor

### DIFF
--- a/Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj
+++ b/Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net462</TargetFrameworks>
     <SignAssembly>True</SignAssembly>    
     <DelaySign>False</DelaySign>    
     <AssemblyOriginatorKeyFile>../keys/Winton.Extensions.Threading.Actor.snk</AssemblyOriginatorKeyFile>

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ dotnet build ./Winton.Extensions.Threading.Actor/Winton.Extensions.Threading.Act
 echo
 
 echo "Testing ..."
-dotnet test ./Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj --configuration Release --framework netcoreapp1.0
+dotnet test ./Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj --configuration Release --framework netcoreapp1.1
 echo
 
 if [ "${TRAVIS:-}" != "true" ]; then


### PR DESCRIPTION
It seems that having the test project as .NET 4.5.1 means that the tests are not detected on appveyor so switched to .NET 4.6.2.