### PR TITLE
Fixed a race condition when stopping very soon after starting.

### DIFF
--- a/Winton.Extensions.Threading.Actor/Internal/StateMachine/ActiveActorState.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/StateMachine/ActiveActorState.cs
@@ -64,6 +64,8 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
 
         protected override void EnterImpl()
         {
+            Context.StartCompletionSource.SetResult(true);
+
             foreach (var task in Context.InitialWorkQueue)
             {
                 Context.StartTask(task);

--- a/Winton.Extensions.Threading.Actor/Internal/StateMachine/ActorContext.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/StateMachine/ActorContext.cs
@@ -25,6 +25,8 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
 
         public List<Task> InitialWorkQueue { get; } = new List<Task>();
 
+        public List<Task> InitialWorkToBeCancelledQueue { get; } = new List<Task>();
+
         public IActorTaskFactory ActorTaskFactory { get; }
 
         public ActorStartWork StartWork

--- a/Winton.Extensions.Threading.Actor/Internal/StateMachine/InitialActorState.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/StateMachine/InitialActorState.cs
@@ -19,7 +19,6 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
             }
             else
             {
-                Context.StartCompletionSource.SetResult(true);
                 Context.SetState<ActiveActorState>();
             }
         }

--- a/Winton.Extensions.Threading.Actor/Internal/StateMachine/StartingActorState.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/StateMachine/StartingActorState.cs
@@ -34,7 +34,6 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
                          {
                              await task.ConfigureAwait(false);
 
-                             Context.StartCompletionSource.SetResult(true);
                              Context.SetState<ActiveActorState>();
 
                              if (ReceivedStopSignal)
@@ -62,7 +61,14 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
 
         protected override void ScheduleImpl(Task task)
         {
-            Context.InitialWorkQueue.Add(task);
+            if (!ReceivedStopSignal)
+            {
+                Context.InitialWorkQueue.Add(task);
+            }
+            else
+            {
+                Context.InitialWorkToBeCancelledQueue.Add(task);
+            }
         }
 
         private bool ReceivedStopSignal { get; set; } = false;

--- a/Winton.Extensions.Threading.Actor/Internal/StateMachine/StoppedActorState.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/StateMachine/StoppedActorState.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
@@ -24,12 +25,13 @@ namespace Winton.Extensions.Threading.Actor.Internal.StateMachine
 
         protected override void EnterImpl()
         {
-            foreach (var task in Context.InitialWorkQueue)
+            foreach (var task in Context.InitialWorkQueue.Concat(Context.InitialWorkToBeCancelledQueue))
             {
                 task.Cancel();
             }
 
             Context.InitialWorkQueue.Clear();
+            Context.InitialWorkToBeCancelledQueue.Clear();
         }
     }
 }


### PR DESCRIPTION
This was shown up in a CI test.

Essentially, work queued after a call to stop whilst the actor was actually in "starting" state would be put on the "initial work queue" rather than being marked as coming after the stop call. One of those tests where you wonder why it didn't fail more often.