### PR TITLE
Appveyor was failing at the versioning step

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - set PATH=C:\msys64\usr\bin;%PATH%
 
 build_script:
-  - bash.exe -lc "./etc/scripts/write_version_targets.sh"
+  - bash.exe -lc "cd $APPVEYOR_BUILD_FOLDER && ./etc/scripts/write_version_targets.sh"
   - ps: .\build.ps1 -VersionAndPublish (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER)
 
 test: off


### PR DESCRIPTION
It seems that previously "bash -lc" would result in a working directory that was the build directory. That behaviour has changed and presumably it is now (correctly) placing you in some home directory.

The solution was to explicitly change to the build directory prior to running the versioning script.