### PR TITLE
fix: do not leave completed ambient transaction if transaction scope is altered in enqueued or startup work

### DIFF
--- a/Winton.Extensions.Threading.Actor.Tests.Unit/Internal/ActorTaskSchedulerTests.cs
+++ b/Winton.Extensions.Threading.Actor.Tests.Unit/Internal/ActorTaskSchedulerTests.cs
@@ -39,7 +39,7 @@ namespace Winton.Extensions.Threading.Actor.Tests.Unit.Internal
             var count = 0;
             var task1 = _actorTaskFactory.StartNew(() => ++count, CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
             var task2 = _actorTaskFactory.StartNew(() => ++count, CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
-            
+
             Task.WhenAny(task1, task2).Wait(TimeSpan.FromSeconds(1)).Should().BeFalse("tasks should not have been executed if the scheduler is paused");
 
             var resumer = _actorTaskFactory.StartNew(() => ++count, CancellationToken.None, TaskCreationOptions.None, resumingTaskTraits);
@@ -54,14 +54,14 @@ namespace Winton.Extensions.Threading.Actor.Tests.Unit.Internal
         {
             UnpauseScheduler();
 
-            var task1 = _actorTaskFactory.StartNew(() => throw new Exception("oh dear"), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
+            var task1 = _actorTaskFactory.StartNew(new Action(() => throw new Exception("oh dear")), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
 
             task1.Awaiting(x => x).Should().Throw<Exception>().WithMessage("oh dear");
 
             _scheduler.TerminatedTask.Wait(TimeSpan.FromMilliseconds(250)).Should().BeFalse();
 
-            var task2 = _actorTaskFactory.StartNew(() => throw new Exception("no!!!"), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.Critical);
-            var task3 = _actorTaskFactory.StartNew(() => throw new Exception("shouldn't hit this"), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
+            var task2 = _actorTaskFactory.StartNew(new Action(() => throw new Exception("no!!!")), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.Critical);
+            var task3 = _actorTaskFactory.StartNew(new Action(() => throw new Exception("shouldn't hit this")), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
 
             task2.Awaiting(x => x).Should().Throw<Exception>().WithMessage("no!!!");
 
@@ -97,7 +97,7 @@ namespace Winton.Extensions.Threading.Actor.Tests.Unit.Internal
 
             var task1 = _actorTaskFactory.StartNew(TerminalWork, CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.Terminal);
             var task2 = _actorTaskFactory.StartNew(() => throw new Exception("shouldn't hit this"), CancellationToken.None, TaskCreationOptions.None, ActorTaskTraits.None);
-            
+
             switch (terminalWorkOutcomeType)
             {
                 case TaskStatus.Canceled:
@@ -269,7 +269,7 @@ namespace Winton.Extensions.Threading.Actor.Tests.Unit.Internal
                     task3ThreadId = Thread.CurrentThread.ManagedThreadId;
                     ActorThreadAssertions.CurrentThreadShouldNotBeThreadPoolThread();
                 }, CancellationToken.None, TaskCreationOptions.None);
-            
+
             barrier.SetResult(true);
 
             ThrowIfWaitTimesOut(task1);

--- a/Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj
+++ b/Winton.Extensions.Threading.Actor.Tests.Unit/Winton.Extensions.Threading.Actor.Tests.Unit.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
+  <PropertyGroup>
     <TargetFrameworks>net5.0</TargetFrameworks>
-    <SignAssembly>True</SignAssembly>    
-    <DelaySign>False</DelaySign>    
+    <SignAssembly>True</SignAssembly>
+    <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyFile>../keys/Winton.Extensions.Threading.Actor.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <LangVersion>latest</LangVersion>

--- a/Winton.Extensions.Threading.Actor/Actor.cs
+++ b/Winton.Extensions.Threading.Actor/Actor.cs
@@ -212,13 +212,15 @@ namespace Winton.Extensions.Threading.Actor
         private async Task Enqueue(Func<Task> asyncAction, CancellationToken cancellationToken, ActorEnqueueOptions options, ActorTaskTraits taskTraits)
         {
             var task = _actorTaskFactory.StartNew(asyncAction, cancellationToken, ActorTaskOptions.GetTaskCreationOptions(options), taskTraits);
-            await await task.ConfigureAwait(false);
+            var nestedTask = await task.ConfigureAwait(false);
+            await nestedTask.ConfigureAwait(false);
         }
 
         private async Task<T> Enqueue<T>(Func<Task<T>> asyncFunction, CancellationToken cancellationToken, ActorEnqueueOptions options, ActorTaskTraits taskTraits)
         {
             var task = _actorTaskFactory.StartNew(asyncFunction, cancellationToken, ActorTaskOptions.GetTaskCreationOptions(options), taskTraits);
-            return await await task.ConfigureAwait(false);
+            var nestedTask = await task.ConfigureAwait(false);
+            return await nestedTask.ConfigureAwait(false);
         }
 
         private enum StateName

--- a/Winton.Extensions.Threading.Actor/ActorExtensions.cs
+++ b/Winton.Extensions.Threading.Actor/ActorExtensions.cs
@@ -186,6 +186,46 @@ namespace Winton.Extensions.Threading.Actor
             return cancellationTokenSource.Token;
         }
 
+        internal static Func<Task<T>> SuppressTransactionScopeWrapper<T>(Func<Task<T>> function)
+        {
+            return async () =>
+            {
+                using (var scope = new TransactionScope(
+                    TransactionScopeOption.Suppress,
+                    TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    try
+                    {
+                        return await function().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        scope.Complete();
+                    }
+                }
+            };
+        }
+
+        internal static Func<Task> SuppressTransactionScopeWrapper(Func<Task> function)
+        {
+            return async () =>
+            {
+                using (var scope = new TransactionScope(
+                    TransactionScopeOption.Suppress,
+                    TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    try
+                    {
+                        await function().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        scope.Complete();
+                    }
+                }
+            };
+        }
+
         internal static Func<T> SuppressTransactionScopeWrapper<T>(Func<T> function)
         {
             return () =>

--- a/Winton.Extensions.Threading.Actor/Internal/ActorTaskFactory.cs
+++ b/Winton.Extensions.Threading.Actor/Internal/ActorTaskFactory.cs
@@ -20,6 +20,26 @@ namespace Winton.Extensions.Threading.Actor.Internal
             return Task.Factory.StartNew(ActorExtensions.SuppressTransactionScopeWrapper(action), cancellationTokenSource.Token, taskCreationOptions | TaskCreationOptions.HideScheduler, _scheduler);
         }
 
+        public Task<Task> StartNew(Func<Task> asyncFunction, CancellationToken cancellationToken, TaskCreationOptions taskCreationOptions, ActorTaskTraits traits = ActorTaskTraits.None)
+        {
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            ActorTask.CurrentActorTaskTraits = traits;
+            ActorTask.CurrentCanceller = cancellationTokenSource;
+
+            return Task.Factory.StartNew(ActorExtensions.SuppressTransactionScopeWrapper(asyncFunction), cancellationTokenSource.Token, taskCreationOptions | TaskCreationOptions.HideScheduler, _scheduler);
+        }
+
+        public Task<Task<T>> StartNew<T>(Func<Task<T>> asyncFunction, CancellationToken cancellationToken, TaskCreationOptions taskCreationOptions, ActorTaskTraits traits = ActorTaskTraits.None)
+        {
+            var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+            ActorTask.CurrentActorTaskTraits = traits;
+            ActorTask.CurrentCanceller = cancellationTokenSource;
+
+            return Task.Factory.StartNew(ActorExtensions.SuppressTransactionScopeWrapper(asyncFunction), cancellationTokenSource.Token, taskCreationOptions | TaskCreationOptions.HideScheduler, _scheduler);
+        }
+
         public Task<T> StartNew<T>(Func<T> function, CancellationToken cancellationToken, TaskCreationOptions taskCreationOptions, ActorTaskTraits traits = ActorTaskTraits.None)
         {
             var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);


### PR DESCRIPTION
Fixes issue #34